### PR TITLE
Stop committing generated build health badges

### DIFF
--- a/.github/workflows/build-zmk-firmware.yml
+++ b/.github/workflows/build-zmk-firmware.yml
@@ -24,7 +24,7 @@ on:
         required: false
         default: "firmware"
       update_build_health:
-        description: "Write build health badge files back to the caller branch."
+        description: "Generate build health badge files as a workflow artifact and job summary."
         type: boolean
         required: false
         default: false
@@ -561,14 +561,6 @@ jobs:
             --folder "$BADGE_FOLDER" \
             --github-output "$GITHUB_OUTPUT" \
             --github-summary "$GITHUB_STEP_SUMMARY"
-
-      - name: 💾 Commit build health badge
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          file_pattern: ${{ inputs.badge_folder }}/**/*
-          commit_message: Update build health badge
-          commit_options: --no-verify
-          push_options: --no-verify
 
       - name: 🎁 Upload build health badge
         uses: actions/upload-artifact@v4

--- a/.github/workflows/update-build-health-badge.yml
+++ b/.github/workflows/update-build-health-badge.yml
@@ -1,4 +1,4 @@
-name: Update build health badge
+name: Generate build health badge artifact
 
 on:
   workflow_call:
@@ -18,10 +18,10 @@ on:
         required: false
         default: "badges/build-health"
       commit_badge:
-        description: "Commit generated badge files back to the caller branch."
+        description: "Deprecated compatibility input. Badge files are never committed."
         type: boolean
         required: false
-        default: true
+        default: false
       tool_repository:
         description: "Repository that contains .github/scripts/write-build-health-badge.py."
         type: string
@@ -49,7 +49,7 @@ on:
         value: ${{ jobs.update.outputs.endpoint_json }}
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: build-health-${{ github.repository }}-${{ github.ref }}
@@ -58,7 +58,7 @@ concurrency:
 jobs:
   update:
     runs-on: ubuntu-latest
-    name: Update build health badge
+    name: Generate build health badge artifact
     outputs:
       badge_dir: ${{ steps.write.outputs.badge_dir }}
       badge_svg: ${{ steps.write.outputs.badge_svg }}
@@ -66,14 +66,6 @@ jobs:
     steps:
       - name: Checkout caller repository
         uses: actions/checkout@v4
-
-      - name: Sync caller branch
-        if: ${{ startsWith(github.ref, 'refs/heads/') }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          git fetch origin "$GITHUB_REF_NAME"
-          git checkout -B "$GITHUB_REF_NAME" "origin/$GITHUB_REF_NAME"
 
       - name: Checkout badge tools
         uses: actions/checkout@v4
@@ -109,15 +101,6 @@ jobs:
             --folder "$BADGE_FOLDER" \
             --github-output "$GITHUB_OUTPUT" \
             --github-summary "$GITHUB_STEP_SUMMARY"
-
-      - name: Commit badge files
-        if: inputs.commit_badge == true
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          file_pattern: ${{ inputs.badge_folder }}/**/*
-          commit_message: Update build health badge
-          commit_options: --no-verify
-          push_options: --no-verify
 
       - name: Upload badge artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
日次ビルドは維持したまま、build healthの生成物をリポジトリへ自動commitしない運用へ変更します。バッジ用JSON/SVGはartifactとjob summaryに残し、既存入力は互換性のためdeprecatedとして受理します。各キーボード側ではGitHub Actionsのネイティブバッジへ切り替えます。Fleet: te9no/zmk-shield-fleet#13